### PR TITLE
Add missing $service parameter

### DIFF
--- a/plugins/auth_ldap/init.php
+++ b/plugins/auth_ldap/init.php
@@ -220,9 +220,10 @@ class Auth_Ldap extends Auth_Base {
      * Required for plugin interface 
      * @param string $login  User's username
      * @param string $password User's password
+	 * @param string $service
      * @return boolean
      */
-    function authenticate($login, $password) {
+    function authenticate($login, $password, $service = '') {
         if ($login && $password) {
 
             if (!function_exists('ldap_connect')) {


### PR DESCRIPTION
[0a2dcacbcf](https://git.tt-rss.org/fox/tt-rss/commit/0a2dcacbcf01e1ebb225570fb99811c4215c6ea9) added a 3rd parameter to the `authenticate` function :

```php
function authenticate($login, $password, $service = '');
```

Without a change, the plugin fails with the error :

```
HP Fatal error:  Declaration of Auth_Ldap::authenticate($login, $password) must be compatible with Plugin::authenticate($login, $password, $service = '') in /opt/ttrss/plugins.local/auth_ldap/init.php on line 225
```

I just added the `$service` parameter, and it seems to work well on my instance.